### PR TITLE
Add Streamer Mode module that hides username

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Current Supported MC Version: `1.20.4`
 - AutoFish (Entity-Based)
 - Specialized Voice Acting for a few modules (featuring people from UCR!)
 - In-Game Mod Menu
+- Streamer Mode (Hide Username from Chat)
 
 ## Planned Features (I think these would be fun to implement):
 - AutoFarm

--- a/src/main/java/com/n4t3m/hibana/event/ChatMessageEvent.java
+++ b/src/main/java/com/n4t3m/hibana/event/ChatMessageEvent.java
@@ -1,0 +1,25 @@
+package com.n4t3m.hibana.event;
+
+import net.minecraft.text.Text;
+
+public class ChatMessageEvent extends Event{
+    private final Text chatMessage;
+    private boolean isCancelled;
+
+    public ChatMessageEvent(Text chatMessage) {
+        this.chatMessage = chatMessage;
+        this.isCancelled = false;
+    }
+
+    public void markAsCancelled() {
+        this.isCancelled = true;
+    }
+
+    public boolean getCancelledStatus() {
+        return this.isCancelled;
+    }
+
+    public Text getChatMessage() {
+        return chatMessage;
+    }
+}

--- a/src/main/java/com/n4t3m/hibana/mixin/ChatHudMixin.java
+++ b/src/main/java/com/n4t3m/hibana/mixin/ChatHudMixin.java
@@ -1,0 +1,25 @@
+package com.n4t3m.hibana.mixin;
+
+import com.n4t3m.hibana.Hibana;
+import com.n4t3m.hibana.event.ChatMessageEvent;
+import net.minecraft.client.gui.hud.ChatHud;
+import net.minecraft.client.gui.hud.MessageIndicator;
+import net.minecraft.network.message.MessageSignatureData;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChatHud.class)
+public class ChatHudMixin {
+
+    @Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V", at = @At("HEAD"), cancellable = true)
+    public void addMessage(Text message, MessageSignatureData signature, int ticks, MessageIndicator indicator, boolean refresh, CallbackInfo ci) {
+        ChatMessageEvent event = new ChatMessageEvent(message);
+        Hibana.getEventManager().notifyListeners(event);
+        if(event.getCancelledStatus()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/n4t3m/hibana/modules/ModuleManager.java
+++ b/src/main/java/com/n4t3m/hibana/modules/ModuleManager.java
@@ -3,6 +3,7 @@ package com.n4t3m.hibana.modules;
 import com.n4t3m.hibana.modules.misc.AutoFishEntityModule;
 import com.n4t3m.hibana.modules.misc.AutoFishSoundModule;
 import com.n4t3m.hibana.modules.misc.AutoRespawnModule;
+import com.n4t3m.hibana.modules.misc.StreamerModeModule;
 import com.n4t3m.hibana.modules.movement.BoatFlyModule;
 import com.n4t3m.hibana.modules.movement.PlayerFlyModule;
 import com.n4t3m.hibana.modules.render.FullBrightModule;
@@ -25,6 +26,7 @@ public class ModuleManager {
     public  static final AutoFishEntityModule autoFishEntityModule = new AutoFishEntityModule();
     public static final AutoAimModule autoAimModule = new AutoAimModule();
     public  static  final KillAuraModule killAuraModule = new KillAuraModule();
+    public static final StreamerModeModule streamerModeModule = new StreamerModeModule();
     private static final String[] colorCodeMap = {
             "§c", // Red
             "§6", // Gold (Orange Substitute)
@@ -43,7 +45,8 @@ public class ModuleManager {
             autoRespawnModule,
             autoFishEntityModule,
             autoAimModule,
-            killAuraModule
+            killAuraModule,
+            streamerModeModule
     );
 
     public static String generateRainbowString(String input) {

--- a/src/main/java/com/n4t3m/hibana/modules/misc/StreamerModeModule.java
+++ b/src/main/java/com/n4t3m/hibana/modules/misc/StreamerModeModule.java
@@ -1,0 +1,39 @@
+package com.n4t3m.hibana.modules.misc;
+
+import com.n4t3m.hibana.Hibana;
+import com.n4t3m.hibana.event.ChatMessageEvent;
+import com.n4t3m.hibana.event.Listener;
+import com.n4t3m.hibana.modules.Module;
+import net.minecraft.client.MinecraftClient;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.function.Consumer;
+
+public class StreamerModeModule extends Module {
+    Consumer<ChatMessageEvent> onRecv = StreamerModeModule::onChatMessage;
+    Listener chatMessageListener = new Listener(onRecv);
+
+    public StreamerModeModule() {
+        super("Streamer Mode","misc", GLFW.GLFW_KEY_O);
+    }
+
+    @Override
+    public void onEnable() {
+        Hibana.getEventManager().addListener(ChatMessageEvent.class, chatMessageListener);
+    }
+
+    @Override
+    public void onDisable() {
+        Hibana.getEventManager().removeListener(ChatMessageEvent.class, chatMessageListener);
+    }
+    public static void onChatMessage(ChatMessageEvent event) {
+        String playerUsername = MinecraftClient.getInstance().getSession().getUsername();
+        if(event.getChatMessage().getString().contains(playerUsername)) {
+            event.markAsCancelled();
+        }
+    }
+
+    public void onTick() {}
+
+
+}

--- a/src/main/resources/modclient.mixins.json
+++ b/src/main/resources/modclient.mixins.json
@@ -11,7 +11,8 @@
     "FishingBobberEntityMixin",
     "KeyBindingMixin",
     "MinecraftClientMixin",
-    "SimpleOptionMixin"
+    "SimpleOptionMixin",
+    "ChatHudMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Upon enabing this module, all chat messasges or notices that contain the player's current username will be dropped from the client side chat.